### PR TITLE
add slots to lightning mocks

### DIFF
--- a/src/lightning-mocks/accordion/accordion.html
+++ b/src/lightning-mocks/accordion/accordion.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/accordionSection/accordionSection.html
+++ b/src/lightning-mocks/accordionSection/accordionSection.html
@@ -4,4 +4,7 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot name="actions"></slot>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/breadcrumbs/breadcrumbs.html
+++ b/src/lightning-mocks/breadcrumbs/breadcrumbs.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/buttonMenu/buttonMenu.html
+++ b/src/lightning-mocks/buttonMenu/buttonMenu.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/carousel/carousel.html
+++ b/src/lightning-mocks/carousel/carousel.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/formElement/formElement.html
+++ b/src/lightning-mocks/formElement/formElement.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/layoutItem/layoutItem.html
+++ b/src/lightning-mocks/layoutItem/layoutItem.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/outputField/outputField.html
+++ b/src/lightning-mocks/outputField/outputField.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/recordEditForm/recordEditForm.html
+++ b/src/lightning-mocks/recordEditForm/recordEditForm.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/recordViewForm/recordViewForm.html
+++ b/src/lightning-mocks/recordViewForm/recordViewForm.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/tab/tab.html
+++ b/src/lightning-mocks/tab/tab.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/tabset/tabset.html
+++ b/src/lightning-mocks/tabset/tabset.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/verticalNavigation/verticalNavigation.html
+++ b/src/lightning-mocks/verticalNavigation/verticalNavigation.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/verticalNavigationOverflow/verticalNavigationOverflow.html
+++ b/src/lightning-mocks/verticalNavigationOverflow/verticalNavigationOverflow.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>

--- a/src/lightning-mocks/verticalNavigationSection/verticalNavigationSection.html
+++ b/src/lightning-mocks/verticalNavigationSection/verticalNavigationSection.html
@@ -4,4 +4,6 @@ All rights reserved.
 SPDX-License-Identifier: MIT
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
 -->
-<template></template>
+<template>
+    <slot></slot>
+</template>


### PR DESCRIPTION
Only add the slots to mocks where the actual component has a slot. Mimic any named slots as well.