### PR TITLE
add title prop back to card stub

### DIFF
--- a/src/lightning-stubs/card/card.js
+++ b/src/lightning-stubs/card/card.js
@@ -8,5 +8,6 @@ import { LightningElement, api } from 'lwc';
 
 export default class Card extends LightningElement {
     @api iconName
+    @api title
     @api variant
 }


### PR DESCRIPTION
Fixes https://github.com/salesforce/sfdx-lwc-jest/issues/57

This was mistakenly removed because `title` is a global html attribute. We need to keep it defined as an `@api` property to prevent a significant amount of console errors when running tests.
