### PR TITLE
Update to include date-style and time-style attributes

### DIFF
--- a/src/lightning-stubs/input/input.js
+++ b/src/lightning-stubs/input/input.js
@@ -14,6 +14,7 @@ export default class Input extends LightningElement {
     @api dateAriaDescribedBy
     @api dateAriaLabel
     @api dateAriaLabelledBy
+    @api dateStyle
     @api disabled
     @api fieldLevelHelp
     @api files
@@ -46,6 +47,7 @@ export default class Input extends LightningElement {
     @api timeAriaControls
     @api timeAriaDescribedBy
     @api timeAriaLabelledBy
+    @api timeStyle
     @api timezone
     @api type
     @api validity


### PR DESCRIPTION
This PR adds the date-style and time-style attributes to the lightining-input stub