### PR TITLE
Added missing title property to lightning-icon stub to address issue #97

### DIFF
--- a/src/lightning-stubs/icon/icon.js
+++ b/src/lightning-stubs/icon/icon.js
@@ -12,4 +12,5 @@ export default class Icon extends LightningElement {
     @api size
     @api src
     @api variant
+	@api title
 }


### PR DESCRIPTION
Have verified that this change causes those errors to go away.