### PR TITLE
Proposed change - make toasts usable in tests

### DIFF
--- a/src/lightning-stubs/platformShowToastEvent/platformShowToastEvent.js
+++ b/src/lightning-stubs/platformShowToastEvent/platformShowToastEvent.js
@@ -4,14 +4,15 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const ShowToastEventName = 'lightning__showtoast';
+export const ShowToastEventName = 'lightning__showtoast';
 
 export class ShowToastEvent extends CustomEvent {
-    constructor() {
+    constructor(toast) {
         super(ShowToastEventName, {
             composed: true,
             cancelable: true,
             bubbles: true,
+            detail: toast
         });
     }
 }


### PR DESCRIPTION
Bringing file inline with lwc-recipe:
https://github.com/salesforce/sfdx-lwc-jest/blob/master/src/lightning-stubs/platformShowToastEvent/platformShowToastEvent.js