### PR TITLE
fix: exclude all node_modules except lightning-stubs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -28,7 +28,9 @@ const jestConfig = {
     transform: {
         '^.+\\.(js|html|css)$': require.resolve('@lwc/jest-transformer')
     },
-    transformIgnorePatterns: ["/node_modules/(?:(?!lightning-stubs.*(js|html|css)))*$"],
+    transformIgnorePatterns: [
+        "/node_modules/(?!(@salesforce/sfdx-lwc-jest/src/lightning-stubs)/)"
+    ],
     resolver: path.resolve(__dirname, './resolver.js'),
     testPathIgnorePatterns: [
       '<rootDir>/node_modules/',

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ const jestConfig = {
         '^.+\\.(js|html|css)$': require.resolve('@lwc/jest-transformer')
     },
     transformIgnorePatterns: [
-        "/node_modules/(?!(@salesforce/sfdx-lwc-jest/src/lightning-stubs)/)"
+        "/node_modules/(?!(.*@salesforce/sfdx-lwc-jest/src/lightning-stubs)/)"
     ],
     resolver: path.resolve(__dirname, './resolver.js'),
     testPathIgnorePatterns: [


### PR DESCRIPTION
This PR properly excludes all the `node_modules/` dependencies from being transformed except the lightning-stubs. On top of fixing large file transformation issues, it also greatly improve the overall performance of the test runner (divide by 3 the test during on the [reciepes](https://github.com/trailheadapps/lwc-recipes) repo).

Fix #107, fix #75.

**Note:** This code change will need to be revisited once npm packages distribute components.