### PR TITLE
Improve test performance by caching module paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@lwc/wire-service": "1.3.7-226.4",
         "@salesforce/wire-service-jest-util": "~2.2.5",
         "chalk": "~4.0.0",
-        "glob": "~7.1.6",
+        "fast-glob": "^3.2.4",
         "jest": "25.5.4",
         "yargs": "~15.3.1"
     },

--- a/src/utils/project.js
+++ b/src/utils/project.js
@@ -8,7 +8,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const GlobSync = require('glob').GlobSync;
+const fg = require('fast-glob');
 
 const PROJECT_ROOT = fs.realpathSync(process.cwd());
 const DEFAULT_NAMESPACE = 'c';
@@ -40,7 +40,7 @@ function getModulePaths() {
     });
 
     for (let i = 0; i < projectPaths.length; i++) {
-        const found = new GlobSync('**/lwc/', { cwd: projectPaths[i] }).found;
+        const found = fg.sync('**/**lwc', { cwd: projectPaths[i], onlyDirectories: true });
         for (let j = 0; j < found.length; j++) {
             paths.push(path.join(projectPaths[i], found[j]));
         }

--- a/src/utils/project.js
+++ b/src/utils/project.js
@@ -40,7 +40,7 @@ function getModulePaths() {
     });
 
     for (let i = 0; i < projectPaths.length; i++) {
-        const found = fg.sync('**/**lwc', { cwd: projectPaths[i], onlyDirectories: true });
+        const found = fg.sync('**/lwc', { cwd: projectPaths[i], onlyDirectories: true });
         for (let j = 0; j < found.length; j++) {
             paths.push(path.join(projectPaths[i], found[j]));
         }

--- a/src/utils/project.js
+++ b/src/utils/project.js
@@ -13,6 +13,8 @@ const GlobSync = require('glob').GlobSync;
 const PROJECT_ROOT = fs.realpathSync(process.cwd());
 const DEFAULT_NAMESPACE = 'c';
 
+const paths = [];
+
 function getSfdxProjectJson() {
     const sfdxProjectJson = path.join(PROJECT_ROOT, 'sfdx-project.json');
 
@@ -27,7 +29,9 @@ function getSfdxProjectJson() {
 
 // get relative path to 'lwc' directory from project root
 function getModulePaths() {
-    const paths = [];
+    if (paths.length > 0) {
+        return paths;
+    }
     const projectPaths = [];
     const packageDirectories = getSfdxProjectJson().packageDirectories;
 

--- a/src/utils/project.js
+++ b/src/utils/project.js
@@ -29,9 +29,8 @@ function getSfdxProjectJson() {
 
 // get relative path to 'lwc' directory from project root
 function getModulePaths() {
-    if (paths.length > 0) {
-        return paths;
-    }
+    if (paths.length > 0) return paths;
+
     const projectPaths = [];
     const packageDirectories = getSfdxProjectJson().packageDirectories;
 
@@ -40,10 +39,7 @@ function getModulePaths() {
     });
 
     for (let i = 0; i < projectPaths.length; i++) {
-        const found = fg.sync('**/lwc', { cwd: projectPaths[i], onlyDirectories: true });
-        for (let j = 0; j < found.length; j++) {
-            paths.push(path.join(projectPaths[i], found[j]));
-        }
+        paths.push(...fg.sync(projectPaths[i] + '/**/lwc', { onlyDirectories: true }));
     }
 
     return paths;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,6 +1402,27 @@
   resolved "https://registry.yarnpkg.com/@lwc/wire-service/-/wire-service-1.3.7-226.4.tgz#8005b60d40b6e3be6e744bbc6a28b158a6826425"
   integrity sha512-0+WmYzLtooP6RS1b/WBGo08LvNtu2w5eSc/B6Gw+i24JSgMP6683xMx7HmIh5/WdLo4CwtPJEEyGt9Zsr6thEg==
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha1-Olgr21OATGum0UZXnEblITDPSjs=
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha1-NNxfTKu8cg9OYPdadH5+zWwXW9M=
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha1-ARuSAqcKY2bkNspcBlhEUoqwSXY=
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
+    fastq "^1.6.0"
+
 "@rollup/plugin-replace@^2.3.1":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.3.2.tgz#da4e0939047f793c2eb5eedfd6c271232d0a033f"
@@ -2953,6 +2974,18 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
+fast-glob@^3.2.4:
+  version "3.2.4"
+  resolved "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
+  integrity sha1-0grvv5lXk4Pn88xmUpFYybmFVNM=
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -2962,6 +2995,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastq@^1.6.0:
+  version "1.8.0"
+  resolved "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
+  integrity sha1-VQ4fn1m7xl/hhctqm02VNXEH9IE=
+  dependencies:
+    reusify "^1.0.4"
 
 fb-watchman@^2.0.0:
   version "2.0.1"
@@ -3163,6 +3203,13 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^5.1.0:
+  version "5.1.1"
+  resolved "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=
+  dependencies:
+    is-glob "^4.0.1"
+
 glob@^7.1.1, glob@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
@@ -3175,7 +3222,7 @@ glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3, glob@^7.1.4, glob@~7.1.6:
+glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -4560,6 +4607,11 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=
+
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -5032,7 +5084,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.2.2:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -5702,6 +5754,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=
+
 rgb-regex@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1"
@@ -5746,6 +5803,11 @@ run-async@^2.2.0:
   integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
   dependencies:
     is-promise "^2.1.0"
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha1-yd06fPn0ssS2JE4XOm7YZuYd1nk=
 
 rxjs@^6.4.0:
   version "6.5.3"


### PR DESCRIPTION
Drastically reduces time taken for tests to run by caching the initial result of getmodulepaths as well as replacing the slow glob package with fast-glob.

One test suite went from taking roughly 5.5 minutes to 20 seconds.

And another from roughly 3 minutes to 16.5 seconds