### PR TITLE
doc: Fixed reference to legacy project name (lwc-jest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Alternatively, you can globally install the package and run directly from the co
 ## Usage
 
 ```
-`lwc-jest [options]` runs Jest unit tests
+`sfdx-lwc-jest [options]` runs Jest unit tests
 
 Options:
   --version             Show version number                            [boolean]


### PR DESCRIPTION
Fixed a reference in documentation to legacy project name (lwc-jest)