### PR TITLE
fix: include setupFilesAfterEnv in jest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@lwc/module-resolver": "1.7.10-228.1",
         "@lwc/synthetic-shadow": "1.7.10-228.1",
         "@lwc/wire-service": "1.7.10-228.1",
-        "@salesforce/wire-service-jest-util": "~2.2.5",
+        "@salesforce/wire-service-jest-util": "~2.4.2",
         "chalk": "~4.0.0",
         "fast-glob": "^3.2.4",
         "jest": "25.5.4",

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,7 @@ const jestConfig = {
     transformIgnorePatterns: [
         '/node_modules/(?!(.*@salesforce/sfdx-lwc-jest/src/lightning-stubs)/)',
     ],
+    setupFilesAfterEnv: jestPreset.setupFilesAfterEnv || [],
     resolver: path.resolve(__dirname, './resolver.js'),
     testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/test/specs/'],
     collectCoverageFrom: getCoveragePaths(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,10 +1483,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@salesforce/wire-service-jest-util@~2.2.5":
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/@salesforce/wire-service-jest-util/-/wire-service-jest-util-2.2.6.tgz#2c667e260da565ece761606c32b4804ef38b7f18"
-  integrity sha512-2Y4FcHAJUnYdR30e+KIcFI7ja9gDx3aoekx+/N1yQKjiUJ85eAxx0vXS2XsRoIsEa79FqxRv6eiDcQBAkRUfJw==
+"@salesforce/wire-service-jest-util@~2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/wire-service-jest-util/-/wire-service-jest-util-2.4.2.tgz#dd61563e55337c5420e3ae2137d10cd3b1711e40"
+  integrity sha512-yYf1AUhvxhEP9fJLrakogkdbNtrBiRprED+N6Vd3oGydDZrShdPwmYgqLKkzFR0HUw00LiSWaUO19yS1z6n0HA==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"


### PR DESCRIPTION
This PR fixes https://github.com/salesforce/sfdx-lwc-jest/issues/172

With the latest LWC including the wire reform, `@salesforce/wire-service-jest-util` >= v2.4.2 along with the `setupFilesAfterEnv` from `@lwc/jest-preset` is required for existing tests for a component using a wire adapter keep passing.

Note: `setupFilesAfterEnv` from `@lwc/jest-preset` is needed for synthetic-shadow also.