### PR TITLE
feat: Add new --skipApiVersionCheck flag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,26 +42,28 @@ Alternatively, you can globally install the package and run directly from the co
 ## Usage
 
 ```
-`sfdx-lwc-jest [options]` runs Jest unit tests
+`sfdx-lwc-jest [options]` runs Jest unit tests in SFDX workspace
 
 Options:
-  --version             Show version number                            [boolean]
-  --coverage            Collect coverage and display in output
+      --version              Show version number                       [boolean]
+      --coverage             Collect coverage and display in output
                                                       [boolean] [default: false]
-  --updateSnapshot, -u  Re-record every snapshot that fails during a test run
+  -u, --updateSnapshot       Re-record every snapshot that fails during a test
+                             run                      [boolean] [default: false]
+      --verbose              Display individual test results with the test suite
+                             hierarchy                [boolean] [default: false]
+      --watch                Watch files for changes and rerun tests related to
+                             changed files            [boolean] [default: false]
+      --debug                Run tests in debug mode
+                             (https://jestjs.io/docs/en/troubleshooting)
                                                       [boolean] [default: false]
-  --verbose             Display individual test results with the test suite
-                        hierarchy                     [boolean] [default: false]
-  --watch               Watch files for changes and rerun tests related to
-                        changed files                 [boolean] [default: false]
-  --debug               Run tests in debug mode
-                        (https://jestjs.io/docs/en/troubleshooting)
-                                                      [boolean] [default: false]
-  --help                Show help                                      [boolean]
+      --skipApiVersionCheck  Disable the "sourceApiVersion" field check before
+                             running tests.           [boolean] [default: false]
+      --help                 Show help                                 [boolean]
 
 Examples:
   sfdx-lwc-jest --coverage  Collect coverage and display in output
-  sfdx-lwc-jest -- --json   All params after `--` will be directly passed to Jest
+  sfdx-lwc-jest -- --json   All params after `--` are directly passed to Jest
 ```
 
 ## Passing Additional Jest CLI Options

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -37,6 +37,12 @@ const testOptions = {
         type: 'boolean',
         default: false,
     },
+
+    skipApiVersionCheck: {
+        description: 'Disable the "sourceApiVersion" field check before running tests',
+        type: 'boolean',
+        default: false,
+    },
 };
 
 module.exports = testOptions;

--- a/src/utils/test-runner.js
+++ b/src/utils/test-runner.js
@@ -18,13 +18,19 @@ const { PROJECT_ROOT, getSfdxProjectJson } = require('./project');
 const { jestConfig, expectedApiVersion, jestPath } = require('../config');
 
 // CLI options we do not want to pass along to Jest
-const OPTIONS_BLACKLIST = ['_', '$0', 'debug', 'd'];
+// prettier-ignore
+const OPTIONS_DISALLOW_LIST = [
+    '_', 
+    '$0', 
+    'debug', 'd', 
+    'skipApiVersionCheck', 'skip-api-version-check'
+];
 
 function getOptions(argv) {
     let options = [];
 
     Object.keys(argv).forEach((arg) => {
-        if (argv[arg] && !OPTIONS_BLACKLIST.includes(arg)) {
+        if (argv[arg] && !OPTIONS_DISALLOW_LIST.includes(arg)) {
             options.push(`--${arg}`);
         }
     });

--- a/src/utils/test-runner.js
+++ b/src/utils/test-runner.js
@@ -31,13 +31,19 @@ function getOptions(argv) {
     return options.concat(argv._);
 }
 
-async function testRunner(argv) {
+function validSourceApiVersion() {
     const sfdxProjectJson = getSfdxProjectJson();
     const apiVersion = sfdxProjectJson.sourceApiVersion;
     if (apiVersion !== expectedApiVersion) {
         error(
             `Invalid sourceApiVersion found in sfdx-project.json. Expected ${expectedApiVersion}, found ${apiVersion}`,
         );
+    }
+}
+
+async function testRunner(argv) {
+    if (!argv.skipApiVersionCheck) {
+        validSourceApiVersion();
     }
 
     const hasCustomConfig = fs.existsSync(path.resolve(PROJECT_ROOT, 'jest.config.js'));

--- a/tests/__snapshots__/help.test.js.snap
+++ b/tests/__snapshots__/help.test.js.snap
@@ -4,19 +4,21 @@ exports[`--help attribute shows help 1`] = `
 "\`sfdx-lwc-jest [options]\` runs Jest unit tests in SFDX workspace
 
 Options:
-      --version         Show version number                            [boolean]
-      --coverage        Collect coverage and display in output
+      --version              Show version number                       [boolean]
+      --coverage             Collect coverage and display in output
                                                       [boolean] [default: false]
-  -u, --updateSnapshot  Re-record every snapshot that fails during a test run
+  -u, --updateSnapshot       Re-record every snapshot that fails during a test
+                             run                      [boolean] [default: false]
+      --verbose              Display individual test results with the test suite
+                             hierarchy                [boolean] [default: false]
+      --watch                Watch files for changes and rerun tests related to
+                             changed files            [boolean] [default: false]
+      --debug                Run tests in debug mode
+                             (https://jestjs.io/docs/en/troubleshooting)
                                                       [boolean] [default: false]
-      --verbose         Display individual test results with the test suite
-                        hierarchy                     [boolean] [default: false]
-      --watch           Watch files for changes and rerun tests related to
-                        changed files                 [boolean] [default: false]
-      --debug           Run tests in debug mode
-                        (https://jestjs.io/docs/en/troubleshooting)
-                                                      [boolean] [default: false]
-      --help            Show help                                      [boolean]
+      --skipApiVersionCheck  Disable the \\"sourceApiVersion\\" field check before
+                             running tests            [boolean] [default: false]
+      --help                 Show help                                 [boolean]
 
 Examples:
   sfdx-lwc-jest --coverage  Collect coverage and display in output


### PR DESCRIPTION
This PR introduces a new advanced flag `--skipApiVersionCheck`. When this flag is passed, sfdx-lwc-jest will not check if the `sfdx-project.json` `sourceApiVersion` field is matching with matching the expected API version.

With this flag, ISV who want to avoid bumping their package API version at a different cadence than Salesforce release can keep their test runner version up-to-date.