### PR TITLE
fix: Retrieve right binary path even if jest is not hoisted

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -37,8 +37,11 @@ const jestConfig = {
 
 const expectedApiVersion = '50.0';
 
-// Execute command is different on Windows.
-const jestPath =
-    process.platform == 'win32' ? './node_modules/jest/bin/jest.js' : 'node_modules/.bin/jest';
+const jestPath = (() => {
+    const packageJsonPath = require.resolve('jest/package.json');
+    const { bin } = require(packageJsonPath);
+
+    return path.resolve(path.dirname(packageJsonPath), bin);
+})();
 
 module.exports = { jestConfig, jestPath, expectedApiVersion };


### PR DESCRIPTION
Instead of hardcoding the expected `jest` bin path, the binary location is retrieved by looking up the package via `require.resolve`.

Fix #155.