### PR TITLE
fix: automock apex methods with valid wire adapters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
     },
     "overrides": [
         {
-            "files": ["src/lightning-stubs/**"],
+            "files": ["src/lightning-stubs/**", "src/apex-stubs/**"],
             "parser": "babel-eslint",
             "parserOptions": {
                 "sourceType": "module"

--- a/src/apex-stubs/apex/apex.js
+++ b/src/apex-stubs/apex/apex.js
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+export const getSObjectValue = jest.fn();
+export const refreshApex = jest.fn();

--- a/src/apex-stubs/apex/apex.js
+++ b/src/apex-stubs/apex/apex.js
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) 2021, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-export const getSObjectValue = jest.fn();
-export const refreshApex = jest.fn();

--- a/src/apex-stubs/method/method.js
+++ b/src/apex-stubs/method/method.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { createApexTestWireAdapter } from '@salesforce/wire-service-jest-util';
+
+export default createApexTestWireAdapter(jest.fn());

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -47,11 +47,19 @@ function resolveAsFile(name, extensions) {
     return undefined;
 }
 
-function getLightningMock(modulePath) {
-    const p = path.join(__dirname, 'lightning-stubs', modulePath);
+function getModuleMock(modulePath, moduleName) {
+    const p = path.join(__dirname, modulePath, moduleName);
     if (fs.existsSync(p)) {
-        return path.join(p, modulePath + '.js');
+        return path.join(p, moduleName + '.js');
     }
+}
+
+function getLightningMock(moduleName) {
+    return getModuleMock('lightning-stubs', moduleName);
+}
+
+function getApexMock(moduleName) {
+    return getModuleMock('apex-stubs', moduleName);
 }
 
 function getModule(modulePath, options) {
@@ -59,6 +67,18 @@ function getModule(modulePath, options) {
 
     if (ns === 'lightning') {
         return getLightningMock(name);
+    }
+
+    // See https://developer.salesforce.com/docs/component-library/documentation/en/lwc/reference_salesforce_modules
+    if (
+        modulePath.startsWith('@salesforce/apex/') ||
+        modulePath.startsWith('@salesforce/apexContinuation/')
+    ) {
+        return getApexMock('method');
+    }
+
+    if (modulePath === '@salesforce/apex') {
+        return getApexMock('apex');
     }
 
     if (ns === DEFAULT_NAMESPACE) {

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -77,10 +77,6 @@ function getModule(modulePath, options) {
         return getApexMock('method');
     }
 
-    if (modulePath === '@salesforce/apex') {
-        return getApexMock('apex');
-    }
-
     if (ns === DEFAULT_NAMESPACE) {
         const paths = getModulePaths();
         for (let i = 0; i < paths.length; i++) {


### PR DESCRIPTION
This PR modifies the resolver so it automatically mocks apex methods with a valid wire adapter.