### PR TITLE
fix: resolve to correct jest path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,15 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "yarn.lock" }}
-          - v1-dependencies-
+          - v2-dependencies-{{ checksum "yarn.lock" }}
+          - v2-dependencies-
 
       - run: yarn install --frozen-lock
 
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "yarn.lock" }}
+          key: v2-dependencies-{{ checksum "yarn.lock" }}
 
       - run: yarn check-license-headers
       - run: yarn format:check

--- a/src/utils/test-runner.js
+++ b/src/utils/test-runner.js
@@ -31,8 +31,10 @@ function validSourceApiVersion() {
 function getJestPath() {
     const packageJsonPath = require.resolve('jest/package.json');
 
-    const { bin } = require(packageJsonPath);
-    return path.resolve(path.dirname(packageJsonPath), bin);
+    const {
+        bin: { jest },
+    } = require(packageJsonPath);
+    return path.resolve(path.dirname(packageJsonPath), jest);
 }
 
 function getJestArgs(argv) {


### PR DESCRIPTION
Fixes an issue which seems to be introduced with https://github.com/salesforce/sfdx-lwc-jest/pull/195

`require(packageJsonPath);` resolves to an object:

```
  "bin": {
    "jest": "bin/jest.js"
  },
```

which is used `return path.resolve(path.dirname(packageJsonPath), bin);` which in turns throws `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Object`

Note: testing in lwc-recipes.