### PR TITLE
chore(package): update reference to git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,14 @@
         "src/",
         "config.js"
     ],
-    "repository": "git@github.com:salesforce/sfdx-lwc-jest.git",
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/salesforce/sfdx-lwc-jest.git"
+    },
+    "bugs": {
+        "url": "https://github.com/salesforce/sfdx-lwc-jest/issues"
+    },
+    "homepage": "https://github.com/salesforce/sfdx-lwc-jest#readme",
     "bin": {
         "lwc-jest": "./bin/sfdx-lwc-jest",
         "sfdx-lwc-jest": "./bin/sfdx-lwc-jest"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+ssh://git@github.com/salesforce/sfdx-lwc-jest.git"
+        "url": "https://github.com/salesforce/sfdx-lwc-jest.git"
     },
     "bugs": {
         "url": "https://github.com/salesforce/sfdx-lwc-jest/issues"


### PR DESCRIPTION
I noticed that [the npm page for this package](https://www.npmjs.com/package/@salesforce/sfdx-lwc-jest) doesn't have a link to the Git repo. I assume it's because of how the repository is listed in `package.json`. So I ran `npm init --yes` to autogenerate the `repository`/`bugs`/`homepage` properties.