### PR TITLE
docs: add note about GitHub Releases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+Newer release notes can be found in [GitHub Releases](https://github.com/salesforce/sfdx-lwc-jest/releases).
+
 ## 0.7.1 (March 3, 2020)
 
 ## Fixes


### PR DESCRIPTION
Fixes #228.

I also added release notes to the GitHub Releases page for 0.12.4, 0.12.5, and 13.0.0.