### PR TITLE
fix: apex automock not returning a resolved promise

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+'use strict';
+
+const path = require('path');
+
+module.exports = {
+    moduleFileExtensions: ['js', 'html'],
+    transform: {
+        '^.+\\.(js|html|css)$': require.resolve('@lwc/jest-transformer'),
+    },
+    resolver: path.resolve(__dirname, './src/resolver.js'),
+    testPathIgnorePatterns: ['<rootDir>/node_modules/'],
+    snapshotSerializers: [require.resolve('@lwc/jest-serializer')],
+};

--- a/src/apex-stubs/method/__tests__/apex-method.test.js
+++ b/src/apex-stubs/method/__tests__/apex-method.test.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import method from '../method';
+
+describe('apex resources', () => {
+    it('should return a resolved promise when apex method is invoked imperatively', () => {
+        let resolved = false;
+        method().then(() => (resolved = true));
+
+        return Promise.resolve().then(() => {
+            expect(resolved).toBe(true);
+        });
+    });
+});

--- a/src/apex-stubs/method/method.js
+++ b/src/apex-stubs/method/method.js
@@ -6,4 +6,4 @@
  */
 import { createApexTestWireAdapter } from '@salesforce/wire-service-jest-util';
 
-export default createApexTestWireAdapter(jest.fn());
+export default createApexTestWireAdapter(jest.fn().mockImplementation(() => Promise.resolve()));


### PR DESCRIPTION
### Details

fixes #230 

#208 automocks apex and apexContinuation methods with the correct test wire adapter instead of those provided by the `@lwc/jest-transformer` ([apex](https://github.com/salesforce/lwc-test/blob/master/packages/%40lwc/jest-transformer/src/transforms/apex-scoped-import.js#L90-L100), [apexContinuation](https://github.com/salesforce/lwc-test/blob/master/packages/%40lwc/jest-transformer/src/transforms/apex-continuation-scoped-import.js)). However, it does not implement correctly the mocked function that is used when invoking imperatively the apex method (the correct implementation is defined [here](https://github.com/salesforce/lwc-test/blob/master/packages/%40lwc/jest-transformer/src/transforms/utils.js#L78)).

This PR mocks the implementation of the apex method to return a resolved promise.