### PR TITLE
Revert "fix: automock apex methods with valid wire adapters (#224)"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
     },
     "overrides": [
         {
-            "files": ["src/lightning-stubs/**", "src/apex-stubs/**"],
+            "files": ["src/lightning-stubs/**"],
             "parser": "babel-eslint",
             "parserOptions": {
                 "sourceType": "module"

--- a/src/apex-stubs/method/method.js
+++ b/src/apex-stubs/method/method.js
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2021, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-import { createApexTestWireAdapter } from '@salesforce/wire-service-jest-util';
-
-export default createApexTestWireAdapter(jest.fn());

--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,7 @@ const jestConfig = {
         '^.+\\.(js|html|css)$': require.resolve('@lwc/jest-transformer'),
     },
     transformIgnorePatterns: [
-        '/node_modules/(?!(.*@salesforce/sfdx-lwc-jest/src/(lightning|apex)-stubs)/)',
+        '/node_modules/(?!(.*@salesforce/sfdx-lwc-jest/src/lightning-stubs)/)',
     ],
     setupFilesAfterEnv: jestPreset.setupFilesAfterEnv || [],
     resolver: path.resolve(__dirname, './resolver.js'),

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -47,19 +47,11 @@ function resolveAsFile(name, extensions) {
     return undefined;
 }
 
-function getModuleMock(modulePath, moduleName) {
-    const p = path.join(__dirname, modulePath, moduleName);
+function getLightningMock(modulePath) {
+    const p = path.join(__dirname, 'lightning-stubs', modulePath);
     if (fs.existsSync(p)) {
-        return path.join(p, moduleName + '.js');
+        return path.join(p, modulePath + '.js');
     }
-}
-
-function getLightningMock(moduleName) {
-    return getModuleMock('lightning-stubs', moduleName);
-}
-
-function getApexMock(moduleName) {
-    return getModuleMock('apex-stubs', moduleName);
 }
 
 function getModule(modulePath, options) {
@@ -67,14 +59,6 @@ function getModule(modulePath, options) {
 
     if (ns === 'lightning') {
         return getLightningMock(name);
-    }
-
-    // See https://developer.salesforce.com/docs/component-library/documentation/en/lwc/reference_salesforce_modules
-    if (
-        modulePath.startsWith('@salesforce/apex/') ||
-        modulePath.startsWith('@salesforce/apexContinuation/')
-    ) {
-        return getApexMock('method');
     }
 
     if (ns === DEFAULT_NAMESPACE) {


### PR DESCRIPTION
This reverts commit 0cc034df1ba2f5c8c71f638bb11c0f7e5f23ec27.

Cherrypicks #234 into the summer21 branch.

This PR reverts #210, and #208 (#231 was never included in summer21 branch). They provided functionality to auto mock apex methods.

**Notes:**
- Test authors will need to keep implementing their own apex (+apexContinuation) methods mocks after this PR is merged.
- These changes were added to the summer21 branch with #224.