### PR TITLE
fix: temporarily remove auto-deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ executors:
     docker:
       - image: circleci/node:14
 
-
 commands:
   save_yarn_cache:
     description: Save cache for future build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,5 @@
 version: 2.1
 
-deploy_filters: &deploy_filters
-  filters:
-    branches:
-      ignore: /.*/
-    tags:
-      # Trigger on tags that begin with `v`
-      only: /^v.*/
-
-
 executors:
   node:
     docker:
@@ -53,30 +44,7 @@ jobs:
           name: Run unit tests
           command: yarn test
 
-  deploy:
-    executor: node
-    steps:
-      - checkout
-      - restore_yarn_cache
-      - run:
-          name: Install dependencies and build
-          command: yarn install --frozen-lockfile
-      - run:
-          name: Configure NPM authentication
-          command: npm config set "//registry.npmjs.org/:_authToken" "$NPM_AUTOMATION_TOKEN"
-      - run:
-          name: Publish package
-          command: yarn release:publish
-
 workflows:
   build_and_test:
     jobs:
       - build
-  build_and_test_and_deploy:
-    jobs:
-      - build:
-          <<: *deploy_filters
-      - deploy:
-          <<: *deploy_filters
-          requires:
-            - build


### PR DESCRIPTION
Temporarily remove auto-deploy while we find a solution for W-11138153.

Once W-11138153 is resolved, we can add this workflow back in. In the meantime, manual publish using `yarn release:publish` is sufficient.