### PR TITLE
fix: add getRecords adaptor to uiRecordApi stub

### DIFF
--- a/src/lightning-stubs/uiRecordApi/uiRecordApi.js
+++ b/src/lightning-stubs/uiRecordApi/uiRecordApi.js
@@ -7,6 +7,7 @@
 import { createLdsTestWireAdapter } from '@salesforce/wire-service-jest-util';
 
 export const getRecord = createLdsTestWireAdapter(jest.fn());
+export const getRecords = createLdsTestWireAdapter(jest.fn());
 export const getRecordCreateDefaults = createLdsTestWireAdapter(jest.fn());
 export const updateRecord = jest.fn().mockResolvedValue({});
 export const createRecord = jest.fn().mockResolvedValue({});


### PR DESCRIPTION
getRecords adaptor was missing in uiRecordApi stub

fixes #282 