### PR TITLE
[LBC][lightning-button] add stretch to button stubs

### DIFF
--- a/src/lightning-stubs/button/button.js
+++ b/src/lightning-stubs/button/button.js
@@ -16,4 +16,5 @@ export default class Button extends LightningElement {
     @api value;
     @api variant;
     @api disableAnimation;
+    @api stretch;
 }


### PR DESCRIPTION
Winter '23 release introduced `stretch` attribute to `lightning-button` component: https://help.salesforce.com/s/articleView?id=release-notes.rn_lwc_components.htm&type=5&release=240