### PR TITLE
allow `jest.config.mjs` and `jest.config.cjs` jest config files

### DIFF
--- a/src/utils/test-runner.js
+++ b/src/utils/test-runner.js
@@ -59,7 +59,9 @@ function getJestArgs(argv) {
     }
 
     // Provide default configuration when none is present at the project root.
-    const hasCustomConfig = fs.existsSync(path.resolve(PROJECT_ROOT, 'jest.config.js'));
+    const hasCustomConfig = fs.existsSync(path.resolve(PROJECT_ROOT, 'jest.config.js'))
+        || fs.existsSync(path.resolve(PROJECT_ROOT, 'jest.config.mjs'))
+        || fs.existsSync(path.resolve(PROJECT_ROOT, 'jest.config.cjs'));
     if (!hasCustomConfig) {
         jestArgs.unshift(`--config=${JSON.stringify(jestConfig)}`);
     }


### PR DESCRIPTION

addresses https://github.com/salesforce/sfdx-lwc-jest/issues/313

allows the cli to recognize `jest.config.mjs` and `jest.config.cjs` as valid jest config files. The `.(mjs|cjs)` extensions are currently not supported.

I have explored adding support for `.json` and `.ts` but have chosen not to include.
- `.json` would require a bit more rework to allow importing on the JSON file. 
- `.ts` would require adding types to the `@lwc/jest-preset` package (and potentially other TS based config)