### PR TITLE
fix: fix initial emit for GraphQL adapters

### DIFF
--- a/src/lightning-stubs/uiGraphQLApi/uiGraphQLApi.js
+++ b/src/lightning-stubs/uiGraphQLApi/uiGraphQLApi.js
@@ -18,7 +18,7 @@ export class graphql extends createTestWireAdapter() {
     constructor(dataCallback) {
         super(dataCallback);
 
-        graphql.emit({ data: undefined, errors: undefined });
+        graphql.emit(undefined);
     }
 }
 


### PR DESCRIPTION
The initial emit on `graphql` wire adapters was sending `{ data: { data: undefined, errors: undefined }, errors: undefined }`. It should be ` { data: undefined, errors: undefined }`.