### PR TITLE
feat: add toast details in platformShowToastEvent stub

### DIFF
--- a/src/lightning-stubs/platformShowToastEvent/platformShowToastEvent.js
+++ b/src/lightning-stubs/platformShowToastEvent/platformShowToastEvent.js
@@ -12,7 +12,7 @@ export class ShowToastEvent extends CustomEvent {
             composed: true,
             cancelable: true,
             bubbles: true,
-            detail: toast
+            detail: toast,
         });
     }
 }

--- a/src/lightning-stubs/platformShowToastEvent/platformShowToastEvent.js
+++ b/src/lightning-stubs/platformShowToastEvent/platformShowToastEvent.js
@@ -7,11 +7,12 @@
 const ShowToastEventName = 'lightning__showtoast';
 
 export class ShowToastEvent extends CustomEvent {
-    constructor() {
+    constructor(toast) {
         super(ShowToastEventName, {
             composed: true,
             cancelable: true,
             bubbles: true,
+            detail: toast
         });
     }
 }


### PR DESCRIPTION
When testing a component that fires multiple toast with `platformShowToastEvent` we need to access the toast configuration in tests like this ([full source](https://github.com/trailheadapps/lwc-recipes/blob/b959183e0442eab510f35b5b2a3f7274a40bb9eb/force-app/main/default/lwc/miscToastNotification/__tests__/miscToastNotification.test.js#L66)):
```js
// Mock handler for toast event
const handler = jest.fn();
// Add event listener to catch toast event
element.addEventListener(ShowToastEventName, handler);

// Some test logic

// Testing fired event
expect(handler).toHaveBeenCalled();
expect(handler.mock.calls[0][0].detail.title).toBe(TOAST_TITLE);
expect(handler.mock.calls[0][0].detail.message).toBe(TOAST_MESSAGE);
expect(handler.mock.calls[0][0].detail.variant).toBe(TOAST_VARIANT);
```

The previous version of the stub did not allow to pass the toast configuration so I made a PR to enable it.

For reference, we've been using this [updated stub](https://github.com/trailheadapps/lwc-recipes/blob/main/force-app/test/jest-mocks/lightning/platformShowToastEvent.js) in our [LWC Recipes tests](https://github.com/trailheadapps/lwc-recipes/blob/b959183e0442eab510f35b5b2a3f7274a40bb9eb/force-app/main/default/lwc/miscToastNotification/__tests__/miscToastNotification.test.js#L66) for years.