### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: '20.11.0'
+                  node-version: '20.12.1'
                   cache: 'yarn'
 
             - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -33,16 +33,16 @@
         "test": "jest"
     },
     "dependencies": {
-        "@lwc/compiler": "6.3.2",
-        "@lwc/engine-dom": "6.3.2",
-        "@lwc/engine-server": "6.3.2",
-        "@lwc/jest-preset": "14.3.0",
-        "@lwc/jest-resolver": "14.3.0",
-        "@lwc/jest-serializer": "14.3.0",
-        "@lwc/jest-transformer": "14.3.0",
-        "@lwc/module-resolver": "6.3.2",
-        "@lwc/synthetic-shadow": "6.3.2",
-        "@lwc/wire-service": "6.3.2",
+        "@lwc/compiler": "6.5.0",
+        "@lwc/engine-dom": "6.5.0",
+        "@lwc/engine-server": "6.5.0",
+        "@lwc/jest-preset": "15.0.0",
+        "@lwc/jest-resolver": "15.0.0",
+        "@lwc/jest-serializer": "15.0.0",
+        "@lwc/jest-transformer": "15.0.0",
+        "@lwc/module-resolver": "6.5.0",
+        "@lwc/synthetic-shadow": "6.5.0",
+        "@lwc/wire-service": "6.5.0",
         "@salesforce/wire-service-jest-util": "4.1.4",
         "fast-glob": "^3.3.2",
         "jest": "29.7.0",
@@ -50,9 +50,9 @@
         "yargs": "~17.7.2"
     },
     "devDependencies": {
-        "@babel/core": "^7.24.0",
-        "@babel/eslint-parser": "^7.23.10",
-        "@babel/plugin-proposal-decorators": "^7.24.0",
+        "@babel/core": "^7.24.4",
+        "@babel/eslint-parser": "^7.24.1",
+        "@babel/plugin-proposal-decorators": "^7.24.1",
         "eslint": "^8.57.0",
         "husky": "^9.0.11",
         "isbinaryfile": "^5.0.2",
@@ -60,8 +60,8 @@
         "prettier": "^3.2.5"
     },
     "volta": {
-        "node": "20.11.0",
-        "yarn": "1.22.19"
+        "node": "20.12.1",
+        "yarn": "1.22.22"
     },
     "lint-staged": {
         "*.js": "eslint",

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,14 @@
     "@babel/highlight" "^7.22.10"
     chalk "^2.4.2"
 
+"@babel/code-frame@^7.24.1", "@babel/code-frame@^7.24.2":
+  version "7.24.2"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.24.2.tgz#718b4b19841809a58b29b68cde80bc5e1aa6d9ae"
+  integrity sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==
+  dependencies:
+    "@babel/highlight" "^7.24.2"
+    picocolors "^1.0.0"
+
 "@babel/compat-data@^7.17.10":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.10.tgz#711dc726a492dfc8be8220028b1b92482362baab"
@@ -56,20 +64,20 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.23.5.tgz#ffb878728bb6bdcb6f4510aa51b1be9afb8cfd98"
   integrity sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==
 
-"@babel/core@7.24.0", "@babel/core@^7.24.0":
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.0.tgz#56cbda6b185ae9d9bed369816a8f4423c5f2ff1b"
-  integrity sha1-Vsvaaxha6dm+02mBao9EI8Xy/xs=
+"@babel/core@7.24.1":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.1.tgz#b802f931b6498dcb8fed5a4710881a45abbc2784"
+  integrity sha512-F82udohVyIgGAY2VVj/g34TpFUG606rumIHjTfVbssPg2zTR7PuuEpZcX8JA6sgBfIYmJrFtWgPvHQuJamVqZQ==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
-    "@babel/code-frame" "^7.23.5"
-    "@babel/generator" "^7.23.6"
+    "@babel/code-frame" "^7.24.1"
+    "@babel/generator" "^7.24.1"
     "@babel/helper-compilation-targets" "^7.23.6"
     "@babel/helper-module-transforms" "^7.23.3"
-    "@babel/helpers" "^7.24.0"
-    "@babel/parser" "^7.24.0"
+    "@babel/helpers" "^7.24.1"
+    "@babel/parser" "^7.24.1"
     "@babel/template" "^7.24.0"
-    "@babel/traverse" "^7.24.0"
+    "@babel/traverse" "^7.24.1"
     "@babel/types" "^7.24.0"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
@@ -119,31 +127,52 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/core@^7.23.3":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.9.tgz#b028820718000f267870822fec434820e9b1e4d1"
-  integrity sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==
+"@babel/core@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.0.tgz#56cbda6b185ae9d9bed369816a8f4423c5f2ff1b"
+  integrity sha1-Vsvaaxha6dm+02mBao9EI8Xy/xs=
   dependencies:
     "@ampproject/remapping" "^2.2.0"
     "@babel/code-frame" "^7.23.5"
     "@babel/generator" "^7.23.6"
     "@babel/helper-compilation-targets" "^7.23.6"
     "@babel/helper-module-transforms" "^7.23.3"
-    "@babel/helpers" "^7.23.9"
-    "@babel/parser" "^7.23.9"
-    "@babel/template" "^7.23.9"
-    "@babel/traverse" "^7.23.9"
-    "@babel/types" "^7.23.9"
+    "@babel/helpers" "^7.24.0"
+    "@babel/parser" "^7.24.0"
+    "@babel/template" "^7.24.0"
+    "@babel/traverse" "^7.24.0"
+    "@babel/types" "^7.24.0"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/eslint-parser@^7.23.10":
-  version "7.23.10"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.23.10.tgz#2d4164842d6db798873b40e0c4238827084667a2"
-  integrity sha512-3wSYDPZVnhseRnxRJH6ZVTNknBz76AEnyC+AYYhasjP3Yy23qz0ERR7Fcd2SHmYuSFJ2kY9gaaDd3vyqU09eSw==
+"@babel/core@^7.24.4":
+  version "7.24.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.4.tgz#1f758428e88e0d8c563874741bc4ffc4f71a4717"
+  integrity sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==
+  dependencies:
+    "@ampproject/remapping" "^2.2.0"
+    "@babel/code-frame" "^7.24.2"
+    "@babel/generator" "^7.24.4"
+    "@babel/helper-compilation-targets" "^7.23.6"
+    "@babel/helper-module-transforms" "^7.23.3"
+    "@babel/helpers" "^7.24.4"
+    "@babel/parser" "^7.24.4"
+    "@babel/template" "^7.24.0"
+    "@babel/traverse" "^7.24.1"
+    "@babel/types" "^7.24.0"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/eslint-parser@^7.24.1":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.24.1.tgz#e27eee93ed1d271637165ef3a86e2b9332395c32"
+  integrity sha512-d5guuzMlPeDfZIbpQ8+g1NaCNuAGBBGNECh0HVqz1sjOeVLh2CEaifuOysCH18URW6R7pqXINvf5PaR/dC6jLQ==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"
@@ -186,6 +215,16 @@
     "@babel/types" "^7.23.6"
     "@jridgewell/gen-mapping" "^0.3.2"
     "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.24.1", "@babel/generator@^7.24.4":
+  version "7.24.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.24.4.tgz#1fc55532b88adf952025d5d2d1e71f946cb1c498"
+  integrity sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==
+  dependencies:
+    "@babel/types" "^7.24.0"
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^2.5.1"
 
 "@babel/helper-annotate-as-pure@^7.22.5":
@@ -242,17 +281,17 @@
     "@babel/helper-split-export-declaration" "^7.22.6"
     semver "^6.3.1"
 
-"@babel/helper-create-class-features-plugin@^7.24.0":
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.0.tgz#fc7554141bdbfa2d17f7b4b80153b9b090e5d158"
-  integrity sha1-/HVUFBvb+i0X97S4AVO5sJDl0Vg=
+"@babel/helper-create-class-features-plugin@^7.24.1":
+  version "7.24.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.4.tgz#c806f73788a6800a5cfbbc04d2df7ee4d927cce3"
+  integrity sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.22.5"
     "@babel/helper-environment-visitor" "^7.22.20"
     "@babel/helper-function-name" "^7.23.0"
     "@babel/helper-member-expression-to-functions" "^7.23.0"
     "@babel/helper-optimise-call-expression" "^7.22.5"
-    "@babel/helper-replace-supers" "^7.22.20"
+    "@babel/helper-replace-supers" "^7.24.1"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.22.5"
     "@babel/helper-split-export-declaration" "^7.22.6"
     semver "^6.3.1"
@@ -386,6 +425,15 @@
     "@babel/helper-member-expression-to-functions" "^7.22.15"
     "@babel/helper-optimise-call-expression" "^7.22.5"
 
+"@babel/helper-replace-supers@^7.24.1":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.24.1.tgz#7085bd19d4a0b7ed8f405c1ed73ccb70f323abc1"
+  integrity sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-member-expression-to-functions" "^7.23.0"
+    "@babel/helper-optimise-call-expression" "^7.22.5"
+
 "@babel/helper-simple-access@^7.17.7":
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz#4dc473c2169ac3a1c9f4a51cfcd091d1c36fcff9"
@@ -473,15 +521,6 @@
     "@babel/traverse" "^7.22.10"
     "@babel/types" "^7.22.10"
 
-"@babel/helpers@^7.23.9":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.9.tgz#c3e20bbe7f7a7e10cb9b178384b4affdf5995c7d"
-  integrity sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==
-  dependencies:
-    "@babel/template" "^7.23.9"
-    "@babel/traverse" "^7.23.9"
-    "@babel/types" "^7.23.9"
-
 "@babel/helpers@^7.24.0":
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.24.0.tgz#a3dd462b41769c95db8091e49cfe019389a9409b"
@@ -489,6 +528,15 @@
   dependencies:
     "@babel/template" "^7.24.0"
     "@babel/traverse" "^7.24.0"
+    "@babel/types" "^7.24.0"
+
+"@babel/helpers@^7.24.1", "@babel/helpers@^7.24.4":
+  version "7.24.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.24.4.tgz#dc00907fd0d95da74563c142ef4cd21f2cb856b6"
+  integrity sha512-FewdlZbSiwaVGlgT1DPANDuCHaDMiOo+D/IDYRFYjHOuv66xMSJ7fQwwODwRNAPkADIO/z1EoF/l2BCWlWABDw==
+  dependencies:
+    "@babel/template" "^7.24.0"
+    "@babel/traverse" "^7.24.1"
     "@babel/types" "^7.24.0"
 
 "@babel/highlight@^7.16.7", "@babel/highlight@^7.23.4":
@@ -508,6 +556,16 @@
     "@babel/helper-validator-identifier" "^7.22.5"
     chalk "^2.4.2"
     js-tokens "^4.0.0"
+
+"@babel/highlight@^7.24.2":
+  version "7.24.2"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.24.2.tgz#3f539503efc83d3c59080a10e6634306e0370d26"
+  integrity sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.20"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+    picocolors "^1.0.0"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.16.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.0", "@babel/parser@^7.23.9":
   version "7.23.9"
@@ -529,6 +587,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.0.tgz#26a3d1ff49031c53a97d03b604375f028746a9ac"
   integrity sha1-JqPR/0kDHFOpfQO2BDdfAodGqaw=
 
+"@babel/parser@^7.24.1", "@babel/parser@^7.24.4":
+  version "7.24.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.4.tgz#234487a110d89ad5a3ed4a8a566c36b9453e8c88"
+  integrity sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==
+
 "@babel/plugin-proposal-async-generator-functions@7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz#bfb7276d2d573cb67ba379984a2334e262ba5326"
@@ -547,14 +610,14 @@
     "@babel/helper-create-class-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-proposal-decorators@^7.24.0":
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.24.0.tgz#845b42189e7441faa60a37682de1038eae97c382"
-  integrity sha1-hFtCGJ50QfqmCjdoLeEDjq6Xw4I=
+"@babel/plugin-proposal-decorators@^7.24.1":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.24.1.tgz#bab2b9e174a2680f0a80f341f3ec70f809f8bb4b"
+  integrity sha512-zPEvzFijn+hRvJuX2Vu3KbEBN39LN3f7tW3MQO2LsIs57B26KU+kUc82BdAktS1VCM6libzh45eKGI65lg0cpA==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.24.0"
+    "@babel/helper-create-class-features-plugin" "^7.24.1"
     "@babel/helper-plugin-utils" "^7.24.0"
-    "@babel/plugin-syntax-decorators" "^7.24.0"
+    "@babel/plugin-syntax-decorators" "^7.24.1"
 
 "@babel/plugin-proposal-dynamic-import@^7.18.6":
   version "7.18.6"
@@ -596,17 +659,17 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-syntax-decorators@^7.23.3":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.23.3.tgz#a1d351d6c25bfdcf2e16f99b039101bc0ffcb0ca"
-  integrity sha512-cf7Niq4/+/juY67E0PbgH0TDhLQ5J7zS8C/Q5FFx+DWyrRa9sUQdTXkjqKu8zGvuqr7vw1muKiukseihU+PJDA==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.22.5"
-
 "@babel/plugin-syntax-decorators@^7.24.0":
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.24.0.tgz#7a15e20aeaf412469c53ed0d5666f31a1fc41215"
   integrity sha1-ehXiCur0EkacU+0NVmbzGh/EEhU=
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.24.0"
+
+"@babel/plugin-syntax-decorators@^7.24.1":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.24.1.tgz#71d9ad06063a6ac5430db126b5df48c70ee885fa"
+  integrity sha512-05RJdO/cCrtVWuAaSn1tS3bH8jbsJa/Y1uD186u6J4C/1mnHFxseeuWpsqr9anvo7TUulev7tm7GDwRV+VuhDw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.0"
 
@@ -763,7 +826,7 @@
     "@babel/parser" "^7.16.7"
     "@babel/types" "^7.16.7"
 
-"@babel/template@^7.22.15", "@babel/template@^7.22.5", "@babel/template@^7.23.9", "@babel/template@^7.3.3":
+"@babel/template@^7.22.15", "@babel/template@^7.22.5", "@babel/template@^7.3.3":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.23.9.tgz#f881d0487cba2828d3259dcb9ef5005a9731011a"
   integrity sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==
@@ -797,22 +860,6 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.23.9":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.9.tgz#2f9d6aead6b564669394c5ce0f9302bb65b9d950"
-  integrity sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==
-  dependencies:
-    "@babel/code-frame" "^7.23.5"
-    "@babel/generator" "^7.23.6"
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-function-name" "^7.23.0"
-    "@babel/helper-hoist-variables" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/parser" "^7.23.9"
-    "@babel/types" "^7.23.9"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
 "@babel/traverse@^7.24.0":
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.24.0.tgz#4a408fbf364ff73135c714a2ab46a5eab2831b1e"
@@ -825,6 +872,22 @@
     "@babel/helper-hoist-variables" "^7.22.5"
     "@babel/helper-split-export-declaration" "^7.22.6"
     "@babel/parser" "^7.24.0"
+    "@babel/types" "^7.24.0"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.24.1":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.24.1.tgz#d65c36ac9dd17282175d1e4a3c49d5b7988f530c"
+  integrity sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==
+  dependencies:
+    "@babel/code-frame" "^7.24.1"
+    "@babel/generator" "^7.24.1"
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-function-name" "^7.23.0"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/parser" "^7.24.1"
     "@babel/types" "^7.24.0"
     debug "^4.3.1"
     globals "^11.1.0"
@@ -1150,6 +1213,15 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
+  integrity sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==
+  dependencies:
+    "@jridgewell/set-array" "^1.2.1"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
@@ -1159,6 +1231,11 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/set-array@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
+  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
 "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15":
   version "1.4.15"
@@ -1181,6 +1258,14 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
 "@locker/babel-plugin-transform-unforgeables@0.20.0":
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/@locker/babel-plugin-transform-unforgeables/-/babel-plugin-transform-unforgeables-0.20.0.tgz#d4c5a280ce0abe1c77ccd8c356e48ecf7b836fa1"
@@ -1189,136 +1274,136 @@
     "@babel/generator" "7.21.4"
     match-json "1.3.5"
 
-"@lwc/babel-plugin-component@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/babel-plugin-component/-/babel-plugin-component-6.3.2.tgz#d45df306997b1a59a36f697a5c4e186f2277ddd9"
-  integrity sha1-1F3zBpl7Glmjb2l6XE4YbyJ33dk=
+"@lwc/babel-plugin-component@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/babel-plugin-component/-/babel-plugin-component-6.5.0.tgz#c794c4960e28af2da5d35c96e0c8df8f5af8b089"
+  integrity sha512-6BPdcOZe8CeyqgVTCDxrzce0b79lLOSxSHiz9gqJJld8LbJHj872Wq8BfFQg3yl81hDtNFlpsfUo7Oremz+OKA==
   dependencies:
     "@babel/helper-module-imports" "7.22.15"
-    "@lwc/errors" "6.3.2"
-    "@lwc/shared" "6.3.2"
+    "@lwc/errors" "6.5.0"
+    "@lwc/shared" "6.5.0"
     line-column "~1.0.2"
 
-"@lwc/compiler@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/compiler/-/compiler-6.3.2.tgz#b2188ae932e9cb408618dd350e5ff94ed43c9287"
-  integrity sha512-e1cEhz1z9IpYkULHRpQ6SIhgDcVxPKGtr+rUU1LNdIp47ET61YcfUIYT6f2qNlbY5++PW/beb5HPGLhvAVEIGA==
+"@lwc/compiler@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/compiler/-/compiler-6.5.0.tgz#dd234e0c32d4fe54f465c7ff676ca457a461b798"
+  integrity sha512-xO8LHoV77LQtE0QBUUwuOWgsxWCK/H3mxxgWeikuTCzoEhtzST+arrLovFwoto65bv+pzCRzcmFG2hZc3Atbdw==
   dependencies:
-    "@babel/core" "7.24.0"
+    "@babel/core" "7.24.1"
     "@babel/plugin-proposal-async-generator-functions" "7.20.7"
     "@babel/plugin-proposal-class-properties" "7.18.6"
     "@babel/plugin-proposal-object-rest-spread" "7.20.7"
     "@babel/plugin-transform-async-to-generator" "7.23.3"
     "@locker/babel-plugin-transform-unforgeables" "0.20.0"
-    "@lwc/babel-plugin-component" "6.3.2"
-    "@lwc/errors" "6.3.2"
-    "@lwc/shared" "6.3.2"
-    "@lwc/style-compiler" "6.3.2"
-    "@lwc/template-compiler" "6.3.2"
+    "@lwc/babel-plugin-component" "6.5.0"
+    "@lwc/errors" "6.5.0"
+    "@lwc/shared" "6.5.0"
+    "@lwc/style-compiler" "6.5.0"
+    "@lwc/template-compiler" "6.5.0"
 
-"@lwc/engine-dom@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/engine-dom/-/engine-dom-6.3.2.tgz#e14e3f7b9aa794fb80e8197f4713038c32707ab1"
-  integrity sha1-4U4/e5qnlPuA6Bl/RxMDjDJwerE=
+"@lwc/engine-dom@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/engine-dom/-/engine-dom-6.5.0.tgz#2eb15d24af565d1e4db1664805c70e54eb7f39eb"
+  integrity sha512-BnW69DPT/Ct74G0ATAEyEE5Y1JxHnAfFQBEvE0ILdGENWJ+Uc25q+e0OiIIoAgWUlp2pAxXb9C2LgYXde3kpIg==
 
-"@lwc/engine-server@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/engine-server/-/engine-server-6.3.2.tgz#ab544ae86adc392259df3b1dae489a82b59dfe78"
-  integrity sha1-q1RK6GrcOSJZ3zsdrkiagrWd/ng=
+"@lwc/engine-server@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/engine-server/-/engine-server-6.5.0.tgz#9850bfc372b99ca1f0287385cfc7bc1d5d6797f9"
+  integrity sha512-6S1GNsL0uBQRLq7u9bYnpN+taqDLkFb9SmaVQwN0RTRHjxY2Flx4yd0ebu+LqCjd6DcCm4DidsbUC8GsR5iBfg==
 
-"@lwc/errors@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/errors/-/errors-6.3.2.tgz#49721a3274f57c3355ad58bc3b0d5aae41da1a65"
-  integrity sha512-FHYdHMnSisT66pfpAjXC0+AXC73nFBnWcevTH4yCSEnfvWrxFtSYt00iKCm/u7uqFAtFsfU5vSB+r3CGQRS/Pw==
+"@lwc/errors@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/errors/-/errors-6.5.0.tgz#1af83ee8bc947460fa627007af2aa752c816e08b"
+  integrity sha512-hbtrIz86IAfmZ+qSa/LPOrPsirHIncotfSfgZoBb+u7q9bqlzUmoKmNKPaNvwtjQSARnCqPa+4DrFUXIGHW7gA==
 
-"@lwc/jest-preset@14.3.0":
-  version "14.3.0"
-  resolved "https://registry.yarnpkg.com/@lwc/jest-preset/-/jest-preset-14.3.0.tgz#7e8c9d03da67c78f4eac1e66ba6d6539053fac2a"
-  integrity sha512-uQjK9lRAXrGZ56t6yWNM+CxdKYC5b884nc3ARNBeDVhrrry1wAlYRzurHL7nZe7PfCubamVtkA83B4kZSIab3A==
+"@lwc/jest-preset@15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@lwc/jest-preset/-/jest-preset-15.0.0.tgz#3ebf885cfaf2274d62559f5c992977605ca3c677"
+  integrity sha512-qwLO9d5WEpG3GTJ4TLmkN53FBZHUlyxr4At6/qsWtv7NXPzVJVxFRdFZDgW+sut2TIfbpD5Ptg3Ex7a+5ul1pA==
   dependencies:
-    "@lwc/jest-resolver" "14.3.0"
-    "@lwc/jest-serializer" "14.3.0"
-    "@lwc/jest-transformer" "14.3.0"
+    "@lwc/jest-resolver" "15.0.0"
+    "@lwc/jest-serializer" "15.0.0"
+    "@lwc/jest-transformer" "15.0.0"
 
-"@lwc/jest-resolver@14.3.0":
-  version "14.3.0"
-  resolved "https://registry.yarnpkg.com/@lwc/jest-resolver/-/jest-resolver-14.3.0.tgz#9f008c14c023c486fe8649fda610e71e2e0b5d95"
-  integrity sha512-an9qYBjP0jTSYlADQnxs+fOdAWahJq0GVnEsBnYF51B3SuqQ9TVBDAJOQXArcoCQsRH1LJMUjLJLHqx2MkjXow==
+"@lwc/jest-resolver@15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@lwc/jest-resolver/-/jest-resolver-15.0.0.tgz#62722476bdbdbab8daaec6fcc2f0f75cc3787771"
+  integrity sha512-vCZfo1ybbYrALlRI3lZc4tbvFq5XsmVT214CVCTUoQ9QzJpiEZwCefULywpX2sW0xoqp89AXuLzeHdek6gSE4Q==
   dependencies:
-    "@lwc/jest-shared" "14.3.0"
+    "@lwc/jest-shared" "15.0.0"
 
-"@lwc/jest-serializer@14.3.0":
-  version "14.3.0"
-  resolved "https://registry.yarnpkg.com/@lwc/jest-serializer/-/jest-serializer-14.3.0.tgz#75fbc12e3f41e3b3092bdb7f0d349ddcbf8eb5ed"
-  integrity sha512-FXo6hWrDmDZgAqVj5/4LPl2epTSMiyidL+IHujqnrYse3aBoCGAJhDkEDWhdQ9+u4atA756X6MH/5YdITZTecw==
+"@lwc/jest-serializer@15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@lwc/jest-serializer/-/jest-serializer-15.0.0.tgz#954f394f47e55d3388d7112de4c7ecacf40cd1c9"
+  integrity sha512-d4cqeiG58h9wuQnA3XvtUcUOmJw8VOBxL4MpsWdABA35rN7Wt5BFWm4mEOZ3L+pnIO7J0Eo9JdZ1w88hJLNjVQ==
   dependencies:
-    "@lwc/jest-shared" "14.3.0"
+    "@lwc/jest-shared" "15.0.0"
     pretty-format "^29.7.0"
 
-"@lwc/jest-shared@14.3.0":
-  version "14.3.0"
-  resolved "https://registry.yarnpkg.com/@lwc/jest-shared/-/jest-shared-14.3.0.tgz#acd6db0fa35b9550ca681c6889c8deffbc16301f"
-  integrity sha512-7/VQci3lGxJPEMaQgUFvjLe4MCmfqN5/Q7LO3GEynexv7FHA5eSbE295Gbv3aWLz9TtCnUhx6c0q3Yj8iEbGkw==
+"@lwc/jest-shared@15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@lwc/jest-shared/-/jest-shared-15.0.0.tgz#0cefb2125d1f37ee4809471accc135a318b6536a"
+  integrity sha512-RUlT789k4xH9NYJsB5uvVo6c+EY5pwrly5aOQje6+jQBHWcBPp7Z/vQFDM/gvft4pmHjyniqR6XCFaJ/BJ702g==
 
-"@lwc/jest-transformer@14.3.0":
-  version "14.3.0"
-  resolved "https://registry.yarnpkg.com/@lwc/jest-transformer/-/jest-transformer-14.3.0.tgz#c8a2e4b7095170f2e624848a5af65a30394d8afb"
-  integrity sha512-sTH8aNXEZiCZiuLQOf/UO7TPJQwFaIHFIP7ljPK57B5VXcgMVKNwgUhrRBvvNKJxNXssa8OsDMBEtJwKOJnMRg==
+"@lwc/jest-transformer@15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@lwc/jest-transformer/-/jest-transformer-15.0.0.tgz#8f8ce80fd733b426fb14c26d1f92f8473f6d0766"
+  integrity sha512-ZsP8eytxZYt5zR6ysLmREiArpmeTUAoom22RbNdiIHytYcC2AcrZWrwju0VleMxJ1pVVkB3xE9nOlGOywdFf1Q==
   dependencies:
-    "@babel/core" "^7.23.3"
+    "@babel/core" "^7.24.0"
     "@babel/plugin-proposal-dynamic-import" "^7.18.6"
     "@babel/plugin-syntax-class-properties" "^7.12.13"
-    "@babel/plugin-syntax-decorators" "^7.23.3"
+    "@babel/plugin-syntax-decorators" "^7.24.0"
     "@babel/plugin-transform-modules-commonjs" "^7.23.3"
     "@babel/preset-typescript" "^7.23.3"
-    "@lwc/jest-shared" "14.3.0"
+    "@lwc/jest-shared" "15.0.0"
     babel-preset-jest "^29.6.3"
-    magic-string "^0.30.5"
-    semver "^7.5.4"
+    magic-string "^0.30.8"
+    semver "^7.6.0"
 
-"@lwc/module-resolver@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/module-resolver/-/module-resolver-6.3.2.tgz#5c5bcb9466b13ba4ccd72cd401949fc99d97cc9c"
-  integrity sha512-5aXoIwwODfhL1did/smFai7Mh4BoLLI9FRjfZrG6DNhUK+shJm6pFTFnznhWG+8YcycN3XofgupSDPEUbfbvnw==
+"@lwc/module-resolver@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/module-resolver/-/module-resolver-6.5.0.tgz#f686b6234068f47431e7aa2e5b95d526251ad965"
+  integrity sha512-bgxCdRygdDQjM9q9r43U5O+qDnod7XiNye8KmAItfogsOE8j278A3BobF6a3sgG9qifpE0IhAQeNw1mejBPXsg==
   dependencies:
     resolve "~1.22.6"
 
-"@lwc/shared@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/shared/-/shared-6.3.2.tgz#72a5ff7e0f0ca76dc4831787e92928f7a95cdc4f"
-  integrity sha512-4YGrtO3QAk/qjpNvUo46Vi/utS19p5K3FNZq5faAyay8r6+GWSlE3Df9z9ouX7RAwgffZcLj3WeadaWgCpZVuQ==
+"@lwc/shared@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/shared/-/shared-6.5.0.tgz#8a634a9ab7baed76db98da35f8dc86ab685e107d"
+  integrity sha512-GkModrLxc7LYZ8Kh9adGwKZHpzlpceCpNlfQPcVvB9EdmOuQVwNwU7+DW3+wFdTm2DdAD8uToSftBsuT4gLwTw==
 
-"@lwc/style-compiler@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/style-compiler/-/style-compiler-6.3.2.tgz#99d008769eb4f7c3f2885367d48e66cd57fa600e"
-  integrity sha512-XoAhcGSqYOAfxsslJK7TX8/bMrwAjhOmm+8x8mARBQ6l7yWbyjpJA/2s+4t3LqOXLxqCH2h5S//+1mP+QfXANg==
+"@lwc/style-compiler@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/style-compiler/-/style-compiler-6.5.0.tgz#789343b09e50f723c141bdca6d96ccc3e4efdde9"
+  integrity sha512-PCxU6IeXLhNoj/de1kzjzOo8SECZLHJ30TrLx50ISwCIr2XfZ7Ay0hItNtZuxj4j+1cZ285SU+eq22hAJCptoQ==
   dependencies:
-    "@lwc/shared" "6.3.2"
-    postcss "~8.4.35"
+    "@lwc/shared" "6.5.0"
+    postcss "~8.4.37"
     postcss-selector-parser "~6.0.15"
     postcss-value-parser "~4.2.0"
 
-"@lwc/synthetic-shadow@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/synthetic-shadow/-/synthetic-shadow-6.3.2.tgz#125d019765ec64fbf1890469a5cdd2a1f7c37012"
-  integrity sha1-El0Bl2XsZPvxiQRppc3SoffDcBI=
+"@lwc/synthetic-shadow@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/synthetic-shadow/-/synthetic-shadow-6.5.0.tgz#c3872501988019e084791caa79b2f4e68a29325d"
+  integrity sha512-0Xn+q0QwTI5DaOawHA9E+/QXTz2+DhOTqcfmYFENPvuqDLnETyiWnnbu9bFoBUMgh1U6eyBN+3sco69oL6xY5Q==
 
-"@lwc/template-compiler@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/template-compiler/-/template-compiler-6.3.2.tgz#63eb7d2057dd3eeb6fc2008d3311d5ac6e31719d"
-  integrity sha1-Y+t9IFfdPutvwgCNMxHVrG4xcZ0=
+"@lwc/template-compiler@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/template-compiler/-/template-compiler-6.5.0.tgz#049b9d07171ceb69c06f0073d36bd26d00191787"
+  integrity sha512-n6zQOatVzjxN1PHmErvN2VoQY9XzPTSh+j5CgzXQlu0bdEU5/KGFMQF3jN8aUvHK49o++t91Q8BN1cKkPcG62g==
   dependencies:
-    "@lwc/errors" "6.3.2"
-    "@lwc/shared" "6.3.2"
+    "@lwc/errors" "6.5.0"
+    "@lwc/shared" "6.5.0"
     acorn "8.10.0"
     astring "~1.8.6"
     estree-walker "~2.0.2"
     he "~1.2.0"
 
-"@lwc/wire-service@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@lwc/wire-service/-/wire-service-6.3.2.tgz#64e6a85303128ec898888607e3e1c3051b864401"
-  integrity sha1-ZOaoUwMSjsiYiIYH4+HDBRuGRAE=
+"@lwc/wire-service@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@lwc/wire-service/-/wire-service-6.5.0.tgz#f5ab9306f428b4e837a3b79a5c6605ead860cb96"
+  integrity sha512-mKkqDyR7DRxEqjDX3rl8jEod13CJX7WNf3uOuq6sqacYTZhD6uADypLUOwlalAkucy3b88JuLrQ9IyPluwswUQ==
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -3381,10 +3466,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-magic-string@^0.30.5:
-  version "0.30.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.7.tgz#0cecd0527d473298679da95a2d7aeb8c64048505"
-  integrity sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==
+magic-string@^0.30.8:
+  version "0.30.9"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.9.tgz#8927ae21bfdd856310e07a1bc8dd5e73cb6c251d"
+  integrity sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
 
@@ -3668,14 +3753,14 @@ postcss-value-parser@~4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@~8.4.35:
-  version "8.4.35"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.35.tgz#60997775689ce09011edf083a549cea44aabe2f7"
-  integrity sha1-YJl3dWic4JAR7fCDpUnOpEqr4vc=
+postcss@~8.4.37:
+  version "8.4.38"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
+  integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
   dependencies:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
-    source-map-js "^1.0.2"
+    source-map-js "^1.2.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -3850,7 +3935,7 @@ semver@^7.5.3:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^7.5.4:
+semver@^7.5.4, semver@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
@@ -3905,10 +3990,10 @@ slice-ansi@^7.0.0:
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^5.0.0"
 
-source-map-js@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
-  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+source-map-js@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
+  integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
 source-map-support@0.5.13:
   version "0.5.13"


### PR DESCRIPTION
BREAKING CHANGE: This is _technically_ a breaking change because we are bumping the `@lwc/jest-*` dependencies to [v15](https://github.com/salesforce/lwc-test/releases/tag/v15.0.0), which means that snapshots may change.

We can do a major version bump as a heads-up.