### PR TITLE
chore: release v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@salesforce/sfdx-lwc-jest",
-    "version": "4.0.1",
+    "version": "5.0.0",
     "description": "Run Jest against LWC components in a Salesforce DX workspace environment",
     "main": "src/index.js",
     "license": "MIT",

--- a/src/config.js
+++ b/src/config.js
@@ -44,6 +44,6 @@ const jestConfig = {
     snapshotSerializers: [require.resolve('@lwc/jest-serializer')],
 };
 
-const expectedApiVersion = '60.0';
+const expectedApiVersion = '61.0';
 
 module.exports = { jestConfig, expectedApiVersion };


### PR DESCRIPTION
This will be the `summer24` release since all the LWC deps are now up to date.