### PR TITLE
chore(dependabot): group lwc/lwc-test deps together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       lwc-test:
         patterns:
           - "@lwc/jest-*"
+      # Group other lwc deps together since they also all depend on each other
+      # See: https://github.com/salesforce/lwc
+      lwc:
+        patterns:
+          - "@lwc/*"
       # Non-major version bumps hopefully shouldn't break anything,
       # so let's group them together into a single PR!
       theoretically-non-breaking:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     schedule:
       interval: "monthly"
     groups:
+      # Group all lwc-test (aka `lwc/jest-*`) deps together since they all depend on each other
+      # See: https://github.com/salesforce/lwc-test
+      lwc-test:
+        patterns:
+          - "@lwc/jest-*"
       # Non-major version bumps hopefully shouldn't break anything,
       # so let's group them together into a single PR!
       theoretically-non-breaking:


### PR DESCRIPTION
These deps can't be updated independently; they all depend on each other.