### PR TITLE
feat(config): add better support for TypeScript

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -28,20 +28,25 @@ function getCoveragePaths() {
 }
 
 const jestConfig = {
-    rootDir: PROJECT_ROOT,
-    moduleFileExtensions: jestPreset.moduleFileExtensions,
+    // Inherited from @lwc/jest-preset
+    moduleFileExtensions: jestPreset.moduleFileExtensions || ['ts', 'js', 'html'],
     testEnvironment: jestPreset.testEnvironment || 'jsdom',
     transform: {
-        '^.+\\.(js|html|css)$': require.resolve('@lwc/jest-transformer'),
+        ...jestPreset.transform,
+        '^.+\\.(js|ts|html|css)$': require.resolve('@lwc/jest-transformer'),
     },
+    setupFilesAfterEnv: jestPreset.setupFilesAfterEnv || [],
+    snapshotSerializers: jestPreset.snapshotSerializers || [
+        require.resolve('@lwc/jest-serializer'),
+    ],
+    // Specific to sfdx-lwc-jest
+    collectCoverageFrom: getCoveragePaths(),
+    resolver: path.join(__dirname, './resolver.js'),
+    rootDir: PROJECT_ROOT,
+    testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/test/specs/'],
     transformIgnorePatterns: [
         '/node_modules/(?!(.*@salesforce/sfdx-lwc-jest/src/lightning-stubs)/)',
     ],
-    setupFilesAfterEnv: jestPreset.setupFilesAfterEnv || [],
-    resolver: path.resolve(__dirname, './resolver.js'),
-    testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/test/specs/'],
-    collectCoverageFrom: getCoveragePaths(),
-    snapshotSerializers: [require.resolve('@lwc/jest-serializer')],
 };
 
 const expectedApiVersion = '61.0';

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ function getCoveragePaths() {
 
 const jestConfig = {
     rootDir: PROJECT_ROOT,
-    moduleFileExtensions: ['js', 'html'],
+    moduleFileExtensions: jestPreset.moduleFileExtensions,
     testEnvironment: jestPreset.testEnvironment || 'jsdom',
     transform: {
         '^.+\\.(js|html|css)$': require.resolve('@lwc/jest-transformer'),


### PR DESCRIPTION
[TypeScript is supported by `@lwc/jest-preset`](https://github.com/salesforce/lwc-test/blob/5b1d20c177c33d5faf7135aa133f3c4a3856b0fa/packages/%40lwc/jest-preset/jest-preset.js#L11-L15), but not by `sfdx-lwc-jest`, even though `sfdx-lwc-jest` builds on `@lwc/jest-preset`.

https://github.com/salesforce/sfdx-lwc-jest/blob/c3ace89953103ce603fa3c620194d71d16cd05f8/src/config.js#L32-L36

This PR updates the config provided by `sfdx-lwc-jest` to support TypeScript by using more of `@lwc/jest-preset`.