### PR TITLE
feat: remove Salesforce source API version dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,6 @@ The npm `latest` tag corresponds to the latest version of this repo, not necessa
 
 To see a full list of available versions, and the tag that maps to the corresponding Salesforce release, see [the list of `npm` package versions](https://www.npmjs.com/package/@salesforce/sfdx-lwc-jest?activeTab=versions).
 
-## Invalid sourceApiVersion found in sfdx-project.json
-
-If you see this error while running tests in your Salesforce DX project, it most likely means you are using the incorrect version of this project.
-
-For example, the error message `Invalid sourceApiVersion found in sfdx-project.json. Expected 45.0, found 46.0` means this project is targeted to API version 45.0, which maps to Spring '19, but the Salesforce DX project the tests are run in is using API version 46.0, which maps to Summer '19. The version check is done against the projects `sourceApiVersion` field in the `sfdx-project.json` file at the top level of the project.
-
-To fix this issue, make sure the most recent version of this project is being used, or switch to the `prerelease` version, depending on what release your target org is on.
-
-## Disabling the sourceApiVersion check
-
-The `sourceApiVersion` field check is not a perfect check. Projects may be targeting orgs that are on the current release, but still have an older `sourceApiVersion` value set in their `sfdx-project.json` file. To disable this check, run tests with the `--skipApiVersionCheck` flag set.
-
-**Note that by doing this, you risk running with an old version of the test runner and your tests may be using an out of date version of the LWC framework. To ensure tests are always run with the proper framework version and configuration, make sure to be on the most recent `latest` or `prerelease` tagged version of this package.**
-
 ## Installation
 
 Add this project as a devDependency:
@@ -71,13 +57,6 @@ Options:
                              changed files            [boolean] [default: false]
       --debug                Run tests in debug mode
                              (https://jestjs.io/docs/en/troubleshooting)
-                                                      [boolean] [default: false]
-      --skipApiVersionCheck  Disable the "sourceApiVersion" field check before
-                             running tests. **Warning** By disabling this check
-                             you risk running tests against stale versions of
-                             the framework. See details here:
-                             https://github.com/salesforce/sfdx-lwc-jest#disabli
-                             ng-the-sourceApiVersion-check
                                                       [boolean] [default: false]
       --help                 Show help                                 [boolean]
 

--- a/src/config.js
+++ b/src/config.js
@@ -44,6 +44,4 @@ const jestConfig = {
     snapshotSerializers: [require.resolve('@lwc/jest-serializer')],
 };
 
-const expectedApiVersion = '61.0';
-
-module.exports = { jestConfig, expectedApiVersion };
+module.exports = { jestConfig };

--- a/src/log.js
+++ b/src/log.js
@@ -13,6 +13,11 @@ function blue(message) {
     return `\x1B[34m${message}\x1B[39m`;
 }
 
+function yellow(message) {
+    // equivalent to chalk.yellow()
+    return `\x1B[33m${message}\x1B[39m`;
+}
+
 function red(message) {
     // equivalent to chalk.red()
     return `\x1B[31m${message}\x1B[39m`;
@@ -22,11 +27,16 @@ function info(message) {
     console.log(`${blue('info')} ${message}`);
 }
 
+function warn(message) {
+    console.warn(`${yellow('warn')} ${message}`);
+}
+
 function error(message) {
     console.error(`${red('error')} ${message}`);
 }
 
 module.exports = {
     info,
+    warn,
     error,
 };

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -39,8 +39,7 @@ const testOptions = {
     },
 
     skipApiVersionCheck: {
-        description:
-            'Disable the "sourceApiVersion" field check before running tests. **Warning** By disabling this check you risk running tests against stale versions of the framework. See details here: https://github.com/salesforce/sfdx-lwc-jest#disabling-the-sourceApiVersion-check',
+        description: 'Deprecated: this noop flag is kept for backward compatibility',
         type: 'boolean',
         default: false,
     },

--- a/src/utils/__mocks__/project.js
+++ b/src/utils/__mocks__/project.js
@@ -6,12 +6,10 @@
  */
 'use strict';
 
-const { expectedApiVersion } = require('../../config');
-
 module.exports = {
     PROJECT_ROOT: 'projectRoot',
     getSfdxProjectJson: () => {
-        return { mock: true, sourceApiVersion: expectedApiVersion };
+        return { mock: true };
     },
     getModulePaths: () => ['force-app/main/unix/lwc', 'force-app\\main\\windows\\lwc'],
 };

--- a/src/utils/test-runner.js
+++ b/src/utils/test-runner.js
@@ -10,23 +10,13 @@ const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
 
-const { PROJECT_ROOT, getSfdxProjectJson } = require('./project');
+const { PROJECT_ROOT } = require('./project');
 
-const { error, info } = require('../log');
-const { jestConfig, expectedApiVersion } = require('../config');
+const { info, warn } = require('../log');
+const { jestConfig } = require('../config');
 
 // List of CLI options that should be passthrough to jest.
 const JEST_PASSTHROUGH_OPTIONS = new Set(['coverage', 'updateSnapshot', 'verbose', 'watch']);
-
-function validSourceApiVersion() {
-    const sfdxProjectJson = getSfdxProjectJson();
-    const apiVersion = sfdxProjectJson.sourceApiVersion;
-    if (apiVersion !== expectedApiVersion) {
-        error(
-            `Invalid sourceApiVersion found in sfdx-project.json. Expected ${expectedApiVersion}, found ${apiVersion}`,
-        );
-    }
-}
 
 function getJestPath() {
     const packageJsonPath = require.resolve('jest/package.json');
@@ -72,9 +62,10 @@ function getJestArgs(argv) {
 
 async function testRunner(argv) {
     if (!argv.skipApiVersionCheck) {
-        validSourceApiVersion();
+        warn(
+            'The --skipApiVersionCheck flag is deprecated and will be removed in future versions.',
+        );
     }
-
     const spawnCommand = 'node';
     const spawnArgs = [getJestPath(), ...getJestArgs(argv)];
 

--- a/tests/__snapshots__/help.test.js.snap
+++ b/tests/__snapshots__/help.test.js.snap
@@ -16,13 +16,8 @@ Options:
       --debug                Run tests in debug mode
                              (https://jestjs.io/docs/en/troubleshooting)
                                                       [boolean] [default: false]
-      --skipApiVersionCheck  Disable the "sourceApiVersion" field check before
-                             running tests. **Warning** By disabling this check
-                             you risk running tests against stale versions of
-                             the framework. See details here:
-                             https://github.com/salesforce/sfdx-lwc-jest#disabli
-                             ng-the-sourceApiVersion-check
-                                                      [boolean] [default: false]
+      --skipApiVersionCheck  Deprecated: this noop flag is kept for backward
+                             compatibility            [boolean] [default: false]
       --help                 Show help                                 [boolean]
 
 Examples:


### PR DESCRIPTION
Following our discussion in #349, I'm proposing to remove the dependency on Salesforce source API version.
This means removing the API version check and deprecating the `--skipApiVersionCheck` flag.

I've kept the flag in order to guarantee backward compatibility and not introduce a breaking change.
If the flag is present, the runner will ignore it and display this warning:
> The --skipApiVersionCheck flag is deprecated and will be removed in future versions.