### PR TITLE
chore: release v5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@salesforce/sfdx-lwc-jest",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "description": "Run Jest against LWC components in a Salesforce DX workspace environment",
     "main": "src/index.js",
     "license": "MIT",


### PR DESCRIPTION
* Removed the Salesforce source API version dependency.
  * The `--skipApiVersion` flag is now deprecated, and has no functionality.
* Added a stub to support the `lightning/platformWorkspaceApi` module.
* Updated the default jest config to inherit from `@lwc/jest-preset`.
  * TypeScript files should now be supported without additional configuration.
