### PR TITLE
chore: release v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@salesforce/sfdx-lwc-jest",
-    "version": "5.1.0",
+    "version": "6.0.0",
     "description": "Run Jest against LWC components in a Salesforce DX workspace environment",
     "main": "src/index.js",
     "license": "MIT",


### PR DESCRIPTION
Bumping major since LWC major version has been bumped.

This will be the version for `winter25`.