### PR TITLE
Added required attritbutes to the file upload stub

### DIFF
--- a/src/lightning-stubs/fileUpload/fileUpload.js
+++ b/src/lightning-stubs/fileUpload/fileUpload.js
@@ -15,4 +15,7 @@ export default class FileUpload extends LightningElement {
     @api multiple;
     @api name;
     @api recordId;
+    @api required;
+    @api reportValidity() {}
+    @api setCustomValidity() {}
 }


### PR DESCRIPTION
Added the required attributes to the fileUpload stub, Teams are blocked on this and require us to update the stub as we are the owner of the component.

![image](https://github.com/user-attachments/assets/0ad8077b-58e7-4136-8ba8-b696ed216f1c)
