### PR TITLE
fix: skipApiVersionCheck flag deprecation warning

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -41,7 +41,6 @@ const testOptions = {
     skipApiVersionCheck: {
         description: 'Deprecated: this noop flag is kept for backward compatibility',
         type: 'boolean',
-        default: false,
     },
 };
 

--- a/src/utils/test-runner.js
+++ b/src/utils/test-runner.js
@@ -61,7 +61,7 @@ function getJestArgs(argv) {
 }
 
 async function testRunner(argv) {
-    if (!argv.skipApiVersionCheck) {
+    if (argv.skipApiVersionCheck !== undefined) {
         warn(
             'The --skipApiVersionCheck flag is deprecated and will be removed in future versions.',
         );

--- a/tests/__snapshots__/help.test.js.snap
+++ b/tests/__snapshots__/help.test.js.snap
@@ -17,7 +17,7 @@ Options:
                              (https://jestjs.io/docs/en/troubleshooting)
                                                       [boolean] [default: false]
       --skipApiVersionCheck  Deprecated: this noop flag is kept for backward
-                             compatibility            [boolean] [default: false]
+                             compatibility                             [boolean]
       --help                 Show help                                 [boolean]
 
 Examples:


### PR DESCRIPTION
The PR fixes an issue #415 where `skipApiVersionCheck` flag deprecation warning would always show up even when the flag was not set because of the default flag value.
I removed the default value and change the check so that the warning only shows up when the flag is set regardless of its value.