### PR TITLE
Add "disabled" property to ButtonStateful

### DIFF
--- a/src/lightning-stubs/buttonStateful/buttonStateful.js
+++ b/src/lightning-stubs/buttonStateful/buttonStateful.js
@@ -7,6 +7,7 @@
 import { LightningElement, api } from 'lwc';
 
 export default class ButtonStateful extends LightningElement {
+    @api disabled;
     @api groupOrder;
     @api iconNameWhenHover;
     @api iconNameWhenOff;


### PR DESCRIPTION
Per the specification:https://developer.salesforce.com/docs/component-library/bundle/lightning-button-stateful/specification

ButtonStateful should have a disabled property

By not having this, we see this warning during tests:

``` 
[LWC warn]: Unknown public property "disabled" of element <lightning-button-stateful>. This is either a typo on the corresponding attribute "disabled", or the attribute does not exist in this browser or DOM implementation
```