### PR TITLE
Add projectJson CLI option for custom project file paths

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,5 +6,5 @@
  */
 'use strict';
 
-const { jestConfig } = require('./src/config');
-module.exports = { jestConfig };
+const { getJestConfig } = require('./src/config');
+module.exports = { jestConfig: getJestConfig() };

--- a/src/config.js
+++ b/src/config.js
@@ -27,26 +27,28 @@ function getCoveragePaths() {
         .flat();
 }
 
-const jestConfig = {
-    // Inherited from @lwc/jest-preset
-    moduleFileExtensions: jestPreset.moduleFileExtensions || ['ts', 'js', 'html'],
-    testEnvironment: jestPreset.testEnvironment || 'jsdom',
-    transform: {
-        ...jestPreset.transform,
-        '^.+\\.(js|ts|html|css)$': require.resolve('@lwc/jest-transformer'),
-    },
-    setupFilesAfterEnv: jestPreset.setupFilesAfterEnv || [],
-    snapshotSerializers: jestPreset.snapshotSerializers || [
-        require.resolve('@lwc/jest-serializer'),
-    ],
-    // Specific to sfdx-lwc-jest
-    collectCoverageFrom: getCoveragePaths(),
-    resolver: path.join(__dirname, './resolver.js'),
-    rootDir: PROJECT_ROOT,
-    testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/test/specs/'],
-    transformIgnorePatterns: [
-        '/node_modules/(?!(.*@salesforce/sfdx-lwc-jest/src/lightning-stubs)/)',
-    ],
-};
+function getJestConfig() {
+    return {
+        // Inherited from @lwc/jest-preset
+        moduleFileExtensions: jestPreset.moduleFileExtensions || ['ts', 'js', 'html'],
+        testEnvironment: jestPreset.testEnvironment || 'jsdom',
+        transform: {
+            ...jestPreset.transform,
+            '^.+\\.(js|ts|html|css)$': require.resolve('@lwc/jest-transformer'),
+        },
+        setupFilesAfterEnv: jestPreset.setupFilesAfterEnv || [],
+        snapshotSerializers: jestPreset.snapshotSerializers || [
+            require.resolve('@lwc/jest-serializer'),
+        ],
+        // Specific to sfdx-lwc-jest
+        collectCoverageFrom: getCoveragePaths(),
+        resolver: path.join(__dirname, './resolver.js'),
+        rootDir: PROJECT_ROOT,
+        testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/test/specs/'],
+        transformIgnorePatterns: [
+            '/node_modules/(?!(.*@salesforce/sfdx-lwc-jest/src/lightning-stubs)/)',
+        ],
+    };
+}
 
-module.exports = { jestConfig };
+module.exports = { getJestConfig };

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -42,6 +42,11 @@ const testOptions = {
         description: 'Deprecated: this noop flag is kept for backward compatibility',
         type: 'boolean',
     },
+
+    projectJson: {
+        description: 'Path to the project JSON file (defaults to sfdx-project.json)',
+        type: 'string',
+    },
 };
 
 module.exports = testOptions;

--- a/src/utils/__mocks__/project.js
+++ b/src/utils/__mocks__/project.js
@@ -12,4 +12,5 @@ module.exports = {
         return { mock: true };
     },
     getModulePaths: () => ['force-app/main/unix/lwc', 'force-app\\main\\windows\\lwc'],
+    setCustomProjectJsonPath: () => {},
 };

--- a/src/utils/project.js
+++ b/src/utils/project.js
@@ -13,13 +13,22 @@ const fg = require('fast-glob');
 const PROJECT_ROOT = fs.realpathSync(process.cwd());
 
 let PATHS = [];
+let CUSTOM_PROJECT_JSON_PATH = null;
+
+function setCustomProjectJsonPath(customPath) {
+    CUSTOM_PROJECT_JSON_PATH = customPath;
+    // Clear cached paths when project JSON changes
+    PATHS = [];
+}
 
 function getSfdxProjectJson() {
-    const sfdxProjectJson = path.join(PROJECT_ROOT, 'sfdx-project.json');
+    const sfdxProjectJson = CUSTOM_PROJECT_JSON_PATH
+        ? path.resolve(CUSTOM_PROJECT_JSON_PATH)
+        : path.join(PROJECT_ROOT, 'sfdx-project.json');
 
     if (!fs.existsSync(sfdxProjectJson)) {
         throw new Error(
-            'Could not find sfdx-project.json. Make sure `lwc-jest` is run from project root',
+            `Could not find ${sfdxProjectJson}. Make sure the project JSON file exists and 'lwc-jest' is run from project root`,
         );
     }
 
@@ -40,4 +49,6 @@ module.exports = {
     PROJECT_ROOT,
     getSfdxProjectJson,
     getModulePaths,
+    setCustomProjectJsonPath,
 };
+3;

--- a/src/utils/test-runner.js
+++ b/src/utils/test-runner.js
@@ -10,10 +10,10 @@ const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
 
-const { PROJECT_ROOT } = require('./project');
+const { PROJECT_ROOT, setCustomProjectJsonPath } = require('./project');
 
 const { info, warn } = require('../log');
-const { jestConfig } = require('../config');
+const { getJestConfig } = require('../config');
 
 // List of CLI options that should be passthrough to jest.
 const JEST_PASSTHROUGH_OPTIONS = new Set(['coverage', 'updateSnapshot', 'verbose', 'watch']);
@@ -54,6 +54,7 @@ function getJestArgs(argv) {
         fs.existsSync(path.resolve(PROJECT_ROOT, 'jest.config.mjs')) ||
         fs.existsSync(path.resolve(PROJECT_ROOT, 'jest.config.cjs'));
     if (!hasCustomConfig) {
+        const jestConfig = getJestConfig();
         jestArgs.unshift(`--config=${JSON.stringify(jestConfig)}`);
     }
 
@@ -61,6 +62,11 @@ function getJestArgs(argv) {
 }
 
 async function testRunner(argv) {
+    // Set custom project JSON path if provided
+    if (argv.projectJson) {
+        setCustomProjectJsonPath(argv.projectJson);
+    }
+
     if (argv.skipApiVersionCheck !== undefined) {
         warn(
             'The --skipApiVersionCheck flag is deprecated and will be removed in future versions.',

--- a/tests/__snapshots__/help.test.js.snap
+++ b/tests/__snapshots__/help.test.js.snap
@@ -18,6 +18,8 @@ Options:
                                                       [boolean] [default: false]
       --skipApiVersionCheck  Deprecated: this noop flag is kept for backward
                              compatibility                             [boolean]
+      --projectJson          Path to the project JSON file (defaults to
+                             sfdx-project.json)                         [string]
       --help                 Show help                                 [boolean]
 
 Examples:

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -7,7 +7,8 @@
 'use strict';
 
 jest.mock('../src/utils/project');
-const { jestConfig } = require('../src/config');
+const { getJestConfig } = require('../src/config');
+const jestConfig = getJestConfig();
 
 test('coveragePaths correctly build', () => {
     expect(jestConfig.collectCoverageFrom).toStrictEqual([


### PR DESCRIPTION
Adds: #436

Changes Summary:
  - Added --projectJson CLI option to specify custom project JSON file path
  - Refactored jestConfig to getJestConfig() function for dynamic configuration
  - Updated all imports and calls accordingly
  - Updated help text and snapshots