### PR TITLE
chore(ci): use latest node v20 in GitHub Actions

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: '20.12.1'
+                  node-version: '20.19.5'
                   cache: 'yarn'
 
             - name: Install dependencies


### PR DESCRIPTION
#453 and #454 are failing because of `engines` checks