### PR TITLE
Adds Toast.show() static mock method for lightning/toast module (#464)

### DIFF
--- a/src/lightning-stubs/toast/toast.js
+++ b/src/lightning-stubs/toast/toast.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { LightningElement, api } from 'lwc';
+
+export default class Toast extends LightningElement {
+    static show() {}
+
+    @api labelLinks;
+    @api messageLinks;
+    @api label;
+    @api message;
+    @api variant;
+    @api mode;
+    @api focus() {}
+}


### PR DESCRIPTION
* Adds Toast.show() static mock method for lightning/toast module

* Update src/lightning-stubs/toast/toast.js



* Run prettier on suggestion

---------