### PR TITLE
chore: add #GUSINFO to CODEOWNERS for OSPO compliance

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:Web Components Framework,LWC OSS Issues


### PR DESCRIPTION
## What

Adds the required `#GUSINFO:` line to `CODEOWNERS` so this repo declares its owning GUS Scrum Team and Product Tag.

```
#GUSINFO:Web Components Framework,LWC OSS Issues
```

## Why

Salesforce OSPO FY27 compliance: every OSS repo's `CODEOWNERS` must declare the responsible GUS team via a `#GUSINFO` line. This repo was flagged as missing it.

Tracking: W-23692797